### PR TITLE
Add the requestContext from AWS to the Request class

### DIFF
--- a/request.js
+++ b/request.js
@@ -25,6 +25,7 @@ class REQUEST {
 		// Set the headers
 		this.headers = app._event.headers
 		
+		// Set the requestContext from the event where one can find the authorizer Context from AWS 
 		this.requestContext = app._event.requestContext
 
 		// console.log(this.headers);

--- a/request.js
+++ b/request.js
@@ -24,6 +24,8 @@ class REQUEST {
 
 		// Set the headers
 		this.headers = app._event.headers
+		
+		this.requestContext = app._event.requestContext
 
 		// console.log(this.headers);
 		// console.log(app._event.body);


### PR DESCRIPTION
When using the AWS API Gateway custom Authorizer, AWS adds the property "requestContext" to the event.  This implementation adds this property to the Request class to avoid that it's being lost.
The requestContext property could then be used by the middle ware to check the principalId (or more)  added by AWS into requestContext.authorizer.principalId.

More info:
[AWS custom authenticator context](https://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html
)
section: Create an API Gateway Custom Authorizer Lambda Function:

> For the Lambda proxy integration, API Gateway passes the context object from a custom authorizer directly to the backend Lambda function as part of the input event. You can retrieve the context key-value pairs in the Lambda function by calling $event.requestContext.authorizer.key. For the preceding custom authorizer example, key is stringKey, numberKey, or booleanKey. Their values are stringified, for example, "stringval", "123", or "true", respectively.


