### PR TITLE
Fixed a bug when having query string params without a leading '/'

### DIFF
--- a/request.js
+++ b/request.js
@@ -45,8 +45,13 @@ class REQUEST {
 			}
 		}
 
-		// Extract path from event
-		let path = app._event.path.trim().replace(/^\/(.*?)(\/)*$/,'$1').split('/')
+        // Extract path from event
+        let path = app._event.path.trim()
+        let queryIndex = path.indexOf('?')
+        if(queryIndex >= 0){
+            path = path.substring(0, queryIndex)
+        }
+        path = path.replace(/^\/(.*?)(\/)*$/,'$1').split('/')
 
 		// Remove base if it exists
 		if (app._base && app._base === path[0]) {

--- a/test/routes.js
+++ b/test/routes.js
@@ -199,6 +199,17 @@ describe('Route Tests:', function() {
       })
     }) // end it
 
+    it('Path with multiple parameters and querystring without tailing slash: /test/123/query/456?test=653', function() {
+        let _event = Object.assign({},event,{ path: '/test/123/query/456', queryStringParameters: { test: '653' } })
+
+        return new Promise((resolve,reject) => {
+            api.run(_event,{},function(err,res) { resolve(res) })
+        }).then((result) => {
+            // console.log(result);
+            expect(result).to.deep.equal({ headers: { 'Content-Type': 'application/json' }, statusCode: 200, body: '{"method":"get","status":"ok","params":{"test":"123","test2":"456"},"query":"653"}' })
+        })
+    }) // end it
+
 
     it('Missing path: /not_found', function() {
       let _event = Object.assign({},event,{ path: '/not_found' })


### PR DESCRIPTION
I encountered a bug with a resulting 404 "Route not found" when calling a url with query string parameters without a leading '/'

lets say that '/test/123/query/456/?test=321' works well (note the '/' before the '?')

but '/test/123/query/456?test=321' results in a 404 as path[i] with i := path.length-1 (the last path) includes the last parameter '456' including the query strings '?test=321' and therefore no route can be found.

In request.js
> // Loop the routes and see if this matches
> 		for (let i=0; i<path.length; i++) {
> 			if (routes[path[i]]) {
> 				routes = routes[path[i]]
> 			} else if (routes['__VAR__']) {
> 				routes = routes['__VAR__']
> 			} else {
> 				app._errorStatus = 404
> 				throw new Error('Route not found')
> 			}
> 		} // end for loop

I basically took a substring of the path until the first encounter of '?'

