### PR TITLE
Add types to npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "LICENSE",
     "README.md",
     "index.js",
+    "index.d.ts",
     "lib/"
   ],
   "engines": {


### PR DESCRIPTION
Currently the types are unusable since they don't get included when publishing to NPM 😅 

This PR fixes the issue by adding the types to the `files` array in `package.json`.