### PR TITLE
Added support for API Gateway Console Test event

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -87,7 +87,7 @@ class REQUEST {
 
     // Set the raw headers (normalize multi-values)
     // per https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2
-    this.rawHeaders = this._multiValueSupport ?
+    this.rawHeaders = this._multiValueSupport && this.app._event.multiValueHeaders !== null ?
       Object.keys(this.app._event.multiValueHeaders).reduce((headers,key) =>
         Object.assign(headers,{ [key]: UTILS.fromArray(this.app._event.multiValueHeaders[key]) }),{})
       : this.app._event.headers || {}

--- a/test/requests.js
+++ b/test/requests.js
@@ -165,6 +165,31 @@ describe('Request Tests:', function() {
       expect(body.request.multiValueHeaders['test-header']).to.deep.equal(['val1','val2'])
     })
 
+    // See: https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-test-method.html
+    it('API Gateway Console Test event', async function() {
+      let _event = require('./sample-event-consoletest1.json')
+      let _context = require('./sample-context-apigateway1.json')
+      let result = await new Promise(r => api.run(_event,_context,(e,res) => { r(res) }))
+      let body = JSON.parse(result.body)
+      // console.log(body);
+      // console.log(body.request.multiValueHeaders);
+      expect(body).to.have.property('request')
+      expect(body.request.id).is.not.null
+      expect(body.request.interface).to.equal('apigateway')
+      expect(body.request).to.have.property('requestContext')
+      expect(body.request.ip).to.equal('test-invoke-source-ip')
+      expect(body.request.pathParameters).to.deep.equal({ "proxy": "test/hello" })
+      expect(body.request.stageVariables).to.deep.equal({})
+      expect(body.request.isBase64Encoded).to.equal(false)
+      expect(body.request.clientType).to.equal('unknown')
+      expect(body.request.clientCountry).to.equal('unknown')
+      expect(body.request.route).to.equal('/test/hello')
+      expect(body.request.query).to.deep.equal({})
+      expect(body.request.multiValueQuery).to.deep.equal({})
+      expect(body.request.headers).to.deep.equal({})
+      // NOTE: body.request.multiValueHeaders is null in this case
+    })
+
   })
 
 }) // end Request tests

--- a/test/sample-event-consoletest1.json
+++ b/test/sample-event-consoletest1.json
@@ -1,0 +1,44 @@
+{
+  "resource": "/{proxy+}",
+  "path": "/test/hello",
+  "httpMethod": "GET",
+  "headers": null,
+  "multiValueHeaders": null,
+  "queryStringParameters": null,
+  "multiValueQueryStringParameters": null,
+  "pathParameters": {
+    "proxy": "test/hello"
+  },
+  "stageVariables": null,
+  "requestContext": {
+    "path": "/{proxy+}",
+    "accountId": "012345678900",
+    "resourceId": "s1swyk",
+    "stage": "test-invoke-stage",
+    "domainPrefix": "testPrefix",
+    "requestId": "3b5b1ca9-80ba-11e9-b4af-a3ad35996092",
+    "identity": {
+      "cognitoIdentityPoolId": null,
+      "cognitoIdentityId": null,
+      "apiKey": "test-invoke-api-key",
+      "principalOrgId": null,
+      "cognitoAuthenticationType": null,
+      "userArn": "arn:aws:iam::012345678900:root",
+      "apiKeyId": "test-invoke-api-key-id",
+      "userAgent": "aws-internal/3 aws-sdk-java/1.11.534 Linux/4.9.137-0.1.ac.218.74.329.metal1.x86_64 OpenJDK_64-Bit_Server_VM/25.202-b08 java/1.8.0_202 vendor/Oracle_Corporation",
+      "accountId": "012345678900",
+      "caller": "012345678900",
+      "sourceIp": "test-invoke-source-ip",
+      "accessKey": "AAAAAAAAAAAAAAAAAAAA",
+      "cognitoAuthenticationProvider": null,
+      "user": "012345678900"
+    },
+    "domainName": "testPrefix.testDomainName",
+    "resourcePath": "/{proxy+}",
+    "httpMethod": "GET",
+    "extendedRequestId": "aW9E_GA3PHcFX0A=",
+    "apiId": "8gd934em46"
+  },
+  "body": null,
+  "isBase64Encoded": false
+}


### PR DESCRIPTION
When using the API Gateway's "Test" feature, lambda-api returns:
`{ error: 'Cannot convert undefined or null to object' }`

due to `multiValueHeaders` being passed as `null` by the API Gateway Console.
I've added a test case and a sample event generated by the console. Request parser is checking whether `multiValueHeaders` is not null.
