### PR TITLE
Make it possible to override the whatever is being consolelogged

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,10 @@ class API {
 
   } // end catch
 
-
+  // Overridable console logger
+  _consoleLog(...logLine) {
+    return console.log(...logLine)
+  }
 
   // Custom callback
   async _callback(err,res,response) {
@@ -311,7 +314,7 @@ class API {
 
     // Output logs
     response._request._logs.forEach(log => {
-      console.log(JSON.stringify(this._logger.detail ? // eslint-disable-line no-console
+      this._consoleLog(JSON.stringify(this._logger.detail ? // eslint-disable-line no-console
         this._logger.format(log,response._request,response) : log))
     })
 
@@ -321,7 +324,7 @@ class API {
         this._logger.log('access',undefined,response._request,response._request.context),
         { statusCode: res.statusCode, coldStart: response._request.coldStart, count: response._request.requestCount }
       )
-      console.log(JSON.stringify(this._logger.format(access,response._request,response))) // eslint-disable-line no-console
+      this._consoleLog(JSON.stringify(this._logger.format(access,response._request,response))) // eslint-disable-line no-console
     }
 
     // Reset global error code


### PR DESCRIPTION
**Background**

We're forwarding CloudWatch logs to a Kinesis, but only if they have a specific prefix in front to the JSON blob.

In order to forward the JSON entries from our lambda-api app we need to be able to customize how the `console.log` method is called.

**Description**

This PR provides a rudimentary customizability for adjusting the final log output, like so:

```js
const api = require('lambda-api')()
// Overwrite the original method
api._consoleLog = (...logLine) => console.log('customStringForTaggingCertainLogOutputs ', ...logLine)
```

Resulting in log entries like so:

```
customStringForTaggingCertainLogOutputs {
    "level": "access",
    "route": "/foo",
    "method": "GET"
    ...
}
```

---

Please let me know if there is something I can do to help get this approved :)