### PR TITLE
Fix and test for #121

### DIFF
--- a/index.js
+++ b/index.js
@@ -467,7 +467,7 @@ class API {
     fn(this,options)
 
     // Remove the last prefix
-    this._prefix = this._prefix.slice(0,-(prefix.length))
+    if(prefix.length) this._prefix = this._prefix.slice(0,-(prefix.length))
 
   } // end register
 

--- a/test/register.js
+++ b/test/register.js
@@ -136,4 +136,14 @@ describe('Register Tests:', function() {
     expect(result).to.deep.equal({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 200, body: '{"path":"/test-register-no-options","route":"/test-register-no-options","method":"GET"}', isBase64Encoded: false })
   }) // end it
 
+  it('Base path w/ multiple unprefixed registers', async function() {
+    const api = require('../index')({
+      base: 'base-path'
+    })
+    api.register((api) => { api.get('/foo', async () => {})}, { prefix: 'fuz'})
+    api.register((api) => { api.get('/bar', async () => {})})
+    api.register((api) => { api.get('/baz', async () => {})})
+    expect(api.routes()).to.deep.equal([["GET", "/base-path/fuz/foo"], ["GET", "/base-path/bar"], ["GET", "/base-path/baz"]])
+  }) // end it
+
 }) // end ROUTE tests


### PR DESCRIPTION
The test case demonstrates how the [bug](https://github.com/jeremydaly/lambda-api/issues/121) manifests.

What the change does: Running `Array.prototype.slice(0, -0)` will effectively slice away everything from start to end; so let's only clean up when there is something to clean.