### PR TITLE
#109 Implement a whitelist for headers as an option to LambdaAPI

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -94,6 +94,7 @@ export declare interface Options {
   };
   serializer?: SerializerFunction;
   version?: string;
+  errorHeaderWhitelist?: string[];
 }
 
 export declare class Request {


### PR DESCRIPTION
This could possibly solve #109, we are testing this implementation in our own stack right now.

It should allow you to pass a whitelist to lambdaApi as such:

```
const api = lambdaApi({
  errorHeaderWhitelist: [
    "Access-Control-Allow-Origin"
  ]
})
```