### PR TITLE
Add default export to match TypeScript definition #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ api.get('/users', (req,res) => {
 })
 ```
 
-### Async/Await  
+### Async/Await
 
 If you prefer to use `async/await`, you can easily apply this to your route functions.
 
@@ -1354,8 +1354,8 @@ If you are using persistent connections in your function routes (such as AWS RDS
 ## TypeScript Support
 An `index.d.ts` declaration file has been included for use with your TypeScript projects (thanks @hassankhan). Please feel free to make suggestions and contributions to keep this up-to-date with future releases.
 
-** TypeScript Example **
-```javascript
+**TypeScript Example**
+```typescript
 // import AWS Lambda types
 import { APIGatewayEvent, Context } from 'aws-lambda';
 // import Lambda API default function

--- a/README.md
+++ b/README.md
@@ -1354,9 +1354,26 @@ If you are using persistent connections in your function routes (such as AWS RDS
 ## TypeScript Support
 An `index.d.ts` declaration file has been included for use with your TypeScript projects (thanks @hassankhan). Please feel free to make suggestions and contributions to keep this up-to-date with future releases.
 
+** TypeScript Example **
 ```javascript
-// import Lambda API and TypeScript declarations
-import API from 'lambda-api'
+// import AWS Lambda types
+import { APIGatewayEvent, Context } from 'aws-lambda';
+// import Lambda API default function
+import createAPI from 'lambda-api'
+
+// instantiate framework
+const api = createAPI();
+
+// Define a route
+api.get('/status', async (req,res) => {
+  return { status: 'ok' }
+})
+
+// Declare your Lambda handler
+exports.run = async (event: APIGatewayEvent, context: Context) => {
+  // Run the request
+  return await api.run(event, context)
+}
 ```
 
 ## Contributions

--- a/index.js
+++ b/index.js
@@ -504,3 +504,5 @@ class API {
 
 // Export the API class as a new instance
 module.exports = opts => new API(opts)
+// Add createAPI as default export (to match index.d.ts)
+module.exports.default = module.exports


### PR DESCRIPTION
It's been a while, but I've bumped into this issue again when using default TypeScript compiler settings (`"esModuleInterop": false`).

Current `index.d.ts` suggests that the initialising function is a default export:
```typescript
declare function createAPI(options?: Options): API;

export default createAPI;
```
but this wasn't the case in index.js

This PR adds that default export without affecting current users.

"TypeScript Example" in README has been updated with a complete lambda-api example (matching JS example) and aws-lambda type imports. It should just work after copy/paste.