### PR TITLE
TypeScript support for api.register/routes, req.namespace (issue #137)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ export declare interface App {
 }
 
 export declare type Middleware = (req: Request, res: Response, next: () => void) => void;
-export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: ErrorHandlingMiddleware) => void;
+export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: () => void) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type HandlerFunction = (req: Request, res: Response, next?: NextFunction) => void | any | Promise<any>;
 export declare type LoggerFunction = (message: string) => void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,8 +32,12 @@ export declare interface FileOptions {
   private?: boolean;
 }
 
+export declare interface RegisterOptions {
+  prefix?: string;
+}
+
 export declare interface App {
-  [namespace: string]: HandlerFunction;
+  [namespace: string]: any;
 }
 
 export declare type Middleware = (req: Request, res: Response, next: () => void) => void;
@@ -138,6 +142,7 @@ export declare class Request {
   userAgent: string;
   clientType: 'desktop' | 'mobile' | 'tv' | 'tablet' | 'unknown';
   clientCountry: string;
+  namespace: App;
 
   log: {
     trace: LoggerFunction;
@@ -202,7 +207,10 @@ export declare class API {
   any(...handler: HandlerFunction[]): void;
   METHOD(method: METHODS, path: string, ...handler: HandlerFunction[]): void;
   METHOD(method: METHODS, ...handler: HandlerFunction[]): void;
-
+  register(routes: (api: API, options?: RegisterOptions) => void, options?: RegisterOptions): void;
+  routes(format: true): void;
+  routes(format: false): string[][];
+  routes(): string[][];
 
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -36,8 +36,10 @@ export declare interface RegisterOptions {
   prefix?: string;
 }
 
+export type Package = any;
+
 export declare interface App {
-  [namespace: string]: any;
+  [namespace: string]: Package;
 }
 
 export declare type Middleware = (req: Request, res: Response, next: () => void) => void;
@@ -186,8 +188,8 @@ export declare class Response {
 }
 
 export declare class API {
-  app(namespace: string, handler: HandlerFunction): App;
-  app(options: App): App;
+  app(namespace: string, package: Package): App;
+  app(packages: App): App;
 
   get(path: string, ...handler: HandlerFunction[]): void;
   get(...handler: HandlerFunction[]): void;


### PR DESCRIPTION
Proposed types for missing api and attributes:

1. api.register(routes, options) where:
a) routes - is a function that registers new handlers e.g.: `(api, opts) => { api.get('/product', handler_v1) }`
b) options (optional) - object which may contain a "prefix" string attribute.

2. api.routes() which:
a) always returns `string[][]`, when called as: `routes()`, `routes(false)`
b) always returns `void`, when called as: `routes(true)` (console log output instead)

3. req.namespace which:
a) is an `App` Object containing `any` object or module for given `string` namespace key, registered against the API instance using the app(...) method.
b) unlike the initial definition, `interface App` does not contain a `HandlerFunction`.
Based on sample usage:
`let userInfo = req.namespace.data.getUser(req.params.userId)`
The `data` key contains a module, which would look like this:
`module.exports = { getUser: (userId) => { return userInfo; } }`
While a `HandlerFunction` represents a `(req, res, next) => {...}` function.
