### PR TITLE
Decode path params

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ const encodeBody = (body,serializer) => {
 exports.encodeBody = encodeBody
 
 exports.parsePath = path => {
-  return path ? path.trim().split('?')[0].replace(/^\/(.*?)(\/)*$/,'$1').split('/') : []
+  return path ? path.trim().split('?')[0].replace(/^\/(.*?)(\/)*$/,'$1').split('/').map(str => decodeURIComponent(str)) : []
 }
 
 


### PR DESCRIPTION
Path parameters should be decoded by the library. This allows application code to use the parameters directly, without decoding it themselves.