### PR TITLE
Fix "this" is undefined for arrow functions

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -124,23 +124,27 @@ exports.generateEtag = data =>
 
 
 // Check if valid S3 path
-exports.isS3 = path => /^s3:\/\/.+\/.+/i.test(path)
+const isS3 = path => /^s3:\/\/.+\/.+/i.test(path)
+
+exports.isS3 = isS3
 
 
 // Parse S3 path
 exports.parseS3 = path => {
-  if (!this.isS3(path)) throw new FileError('Invalid S3 path',{path})
+  if (!isS3(path)) throw new FileError('Invalid S3 path',{path})
   let s3object = path.replace(/^s3:\/\//i,'').split('/')
   return { Bucket: s3object.shift(), Key: s3object.join('/') }
 }
 
 
 // Deep Merge
-exports.deepMerge = (a,b) => {
+const deepMerge = (a,b) => {
   Object.keys(b).forEach(key => (key in a) ?
-    this.deepMerge(a[key],b[key]) : Object.assign(a,b) )
+    deepMerge(a[key],b[key]) : Object.assign(a,b) )
   return a
 }
+
+exports.deepMerge = deepMerge
 
 exports.mergeObjects = (obj1,obj2) =>
   Object.keys(Object.assign({},obj1,obj2)).reduce((acc,key) => {


### PR DESCRIPTION
The utility functions `parseS3` and `deepMerge` are using `this`. Both functions are arrow functions, so `this` is `undefined`. This pull request fixes both functions.