### PR TITLE
feat(cookies/types): add 'None' as a valid sameSite value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,7 @@ export declare interface CookieOptions {
   maxAge?: number;
   path?: string;
   secure?: boolean;
-  sameSite?: boolean | 'Strict' | 'Lax';
+  sameSite?: boolean | 'Strict' | 'Lax' | 'None';
 }
 
 export declare interface CorsOptions {


### PR DESCRIPTION
None is a valid value for SameSite and useful in certain cases.