### PR TITLE
Define overloads for LoggerFunction in type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,10 +46,7 @@ export declare type Middleware = (req: Request, res: Response, next: () => void)
 export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: () => void) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type HandlerFunction = (req: Request, res: Response, next?: NextFunction) => void | any | Promise<any>;
-declare function LogFn (message: string): void;
-declare function LogFn (obj: Record<string, any>): void;
-declare function LogFn (message: string, obj?: Record<string, any>): void
-export declare type LoggerFunction = typeof LogFn;
+export declare type LoggerFunction = (message: string, additionalInfo?: any) => void;
 export declare type NextFunction = () => void;
 export declare type TimestampFunction = () => string;
 export declare type SerializerFunction = (body: object) => string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,7 +46,10 @@ export declare type Middleware = (req: Request, res: Response, next: () => void)
 export declare type ErrorHandlingMiddleware = (error: Error, req: Request, res: Response, next: () => void) => void;
 export declare type ErrorCallback = (error?: Error) => void;
 export declare type HandlerFunction = (req: Request, res: Response, next?: NextFunction) => void | any | Promise<any>;
-export declare type LoggerFunction = (message: string) => void;
+declare function LogFn (message: string): void;
+declare function LogFn (obj: Record<string, any>): void;
+declare function LogFn (message: string, obj?: Record<string, any>): void
+export declare type LoggerFunction = typeof LogFn;
 export declare type NextFunction = () => void;
 export declare type TimestampFunction = () => string;
 export declare type SerializerFunction = (body: object) => string;


### PR DESCRIPTION
I converted a route to Typescript and things went 💥 

Turns out the type definition for the logger methods only expects a string.

![](https://i.imgur.com/3yD8KMd.png)

This PR makes it behave in accordance with the [README](https://github.com/jeremydaly/lambda-api#adding-additional-detail)