### PR TITLE
fix(Response/type): resolve void returned instead of this

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -176,7 +176,7 @@ export declare class Response {
   json(body: any): void;
   jsonp(body: any): void;
   html(body: any): void;
-  type(type: string): void;
+  type(type: string): this;
   location(path: string): this;
   redirect(status: number, path: string): void;
   redirect(path: string): void;


### PR DESCRIPTION
It is valid to chain `response.type('application/xml').status(200).send(xml)` because the `type` function returns an instance of **this**. This change correct the `index.d.ts` typing description from incorrectly returning **void** to correctly returning **this** as apparent from `lib/response.js` .