### PR TITLE
fix(types): resolve use func not allowing to mix middlewares

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -224,8 +224,7 @@ export declare class API {
 
   use(path: string, ...middleware: Middleware[]): void;
   use(paths: string[], ...middleware: Middleware[]): void;
-  use(...middleware: Middleware[]): void;
-  use(...errorHandlingMiddleware: ErrorHandlingMiddleware[]): void;
+  use(...middleware: (Middleware | ErrorHandlingMiddleware)[]): void;
 
   finally(callback: FinallyFunction): void;
 


### PR DESCRIPTION
Currently the use function allows for inputs to be either Middleware or ErrorHandlingMiddleware. However, the typescript type requires the list of arguments to be only Middleware or only ErrorHandlingMiddleware. I.e. you couldn't call api.use with both error middleware and normal middleware. This pr brings the typescript type back into line with code expectation.

Code Section in question:
https://github.com/jeremydaly/lambda-api/blob/c1fe83e53d56eb23c4ef755c01bf1ebc07a7c342/index.js#L355-L383