### PR TITLE
Compression - Disable Brotli by Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -1411,7 +1411,15 @@ const api = require('lambda-api')({
 });
 ```
 
-The response will automatically be compressed based on the `Accept-Encoding` header in the request. Supported compressions are Brotli, Gzip and Deflate - in that priority order.
+The response will automatically be compressed based on the `Accept-Encoding` header in the request. Supported compressions are Gzip and Deflate, with opt-in support for Brotli:
+
+```javascript
+const api = require('lambda-api')({
+  compression: ['br', 'gzip'],
+});
+```
+
+> Note: Brotli compression is significantly slower than Gzip due to its CPU intensive algorithm. Please test extensively before enabling on a production environment.
 
 For full control over the response compression, instantiate the API with `isBase64` set to true, and a custom serializer that returns a compressed response as a base64 encoded string. Also, don't forget to set the correct `content-encoding` header:
 

--- a/__tests__/responses.unit.js
+++ b/__tests__/responses.unit.js
@@ -29,7 +29,7 @@ const api4 = require('../index')({
 // Init API with compression
 const api5 = require('../index')({
   version: 'v1.0',
-  compression: true
+  compression: ['br', 'gzip', 'deflate']
 })
 
 let event = {

--- a/__tests__/responses.unit.js
+++ b/__tests__/responses.unit.js
@@ -312,6 +312,14 @@ describe('Response Tests:', function() {
     expect(result).toEqual({ multiValueHeaders: { 'content-encoding': ['deflate'], 'content-type': ['application/json'] }, statusCode: 200, body, isBase64Encoded: true })
   }) // end it
 
+  it('Compression (Unknown)', async function() {
+    let _event = Object.assign({},event,{ path: '/testCompression'})
+    _event.multiValueHeaders['Accept-Encoding'] = ['xxx']
+    let result = await new Promise(r => api5.run(_event,{},(e,res) => { r(res) }))
+    let body = `{"object":true}`
+    expect(result).toEqual({ multiValueHeaders: { 'content-type': ['application/json'] }, statusCode: 200, body, isBase64Encoded: false })
+  }) // end it
+
   afterEach(function() {
     stub.restore()
   })

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class API {
         ? props.headers
         : {};
     this._compression =
-      props && typeof props.compression === 'boolean'
+      props && (typeof props.compression === 'boolean' || Array.isArray(props.compression))
         ? props.compression
         : false;
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ class API {
         ? props.headers
         : {};
     this._compression =
-      props && (typeof props.compression === 'boolean' || Array.isArray(props.compression))
+      props &&
+      (typeof props.compression === 'boolean' ||
+        Array.isArray(props.compression))
         ? props.compression
         : false;
 

--- a/lib/compression.js
+++ b/lib/compression.js
@@ -8,7 +8,10 @@
 
 const zlib = require('zlib');
 
-exports.compress = (input, headers) => {
+const defaultEnabledEcodings = ['gzip', 'deflate'];
+
+exports.compress = (input, headers, _enabledEncodings) => {
+  const enabledEncodings = new Set(_enabledEncodings || defaultEnabledEcodings);
   const acceptEncodingHeader = headers['accept-encoding'] || '';
   const acceptableEncodings = new Set(
     acceptEncodingHeader
@@ -20,6 +23,7 @@ exports.compress = (input, headers) => {
   // Handle Brotli compression (Only supported in Node v10 and later)
   if (
     acceptableEncodings.has('br') &&
+    enabledEncodings.has('br') &&
     typeof zlib.brotliCompressSync === 'function'
   ) {
     return {
@@ -29,7 +33,7 @@ exports.compress = (input, headers) => {
   }
 
   // Handle Gzip compression
-  if (acceptableEncodings.has('gzip')) {
+  if (acceptableEncodings.has('gzip') && enabledEncodings.has('gzip')) {
     return {
       data: zlib.gzipSync(input),
       contentEncoding: 'gzip',
@@ -37,7 +41,7 @@ exports.compress = (input, headers) => {
   }
 
   // Handle deflate compression
-  if (acceptableEncodings.has('deflate')) {
+  if (acceptableEncodings.has('deflate') && enabledEncodings.has('deflate')) {
     return {
       data: zlib.deflateSync(input),
       contentEncoding: 'deflate',

--- a/lib/response.js
+++ b/lib/response.js
@@ -566,7 +566,8 @@ class RESPONSE {
     if (this._compression && this._response.body) {
       const { data, contentEncoding } = compression.compress(
         this._response.body,
-        this._request.headers
+        this._request.headers,
+        Array.isArray(this._compression) ? this._compression : null
       );
       if (contentEncoding) {
         Object.assign(this._response, {


### PR DESCRIPTION
- Disables Brotli compression by default due to its excessive CPU usage.
- Provides an API to opt-in to Brotli compression