### PR TITLE
Preserve error names even if code is bundled and class names are changed to avoid duplicates

### DIFF
--- a/__tests__/errorHandling.unit.js
+++ b/__tests__/errorHandling.unit.js
@@ -14,6 +14,7 @@ const api_errors = require('../index')({ version: 'v1.0' })
 const api6 = require('../index')() // no props
 const api7 = require('../index')({ version: 'v1.0', logger: { errorLogging: false }})
 const api8 = require('../index')({ version: 'v1.0', logger: { access: 'never', errorLogging: true }})
+const errors = require('../lib/errors');
 
 // Init API with custom gzip serializer and base64
 const api9 = require('../index')({
@@ -274,10 +275,22 @@ describe('Error Handling Tests:', function() {
       expect(result).toEqual({ multiValueHeaders: { }, statusCode: 404, body: '{"errorType":"RouteError"}', isBase64Encoded: false })
     }) // end it
 
+    it('RouteError.name', async function() {
+      let Error$1 = errors.RouteError
+      let error = new Error$1('This is a test error')
+      expect(error.name).toEqual('RouteError')
+    }) // end it
+
     it('MethodError', async function() {
       let _event = Object.assign({},event,{ path: '/fileError', httpMethod: 'put' })
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
       expect(result).toEqual({ multiValueHeaders: { }, statusCode: 405, body: '{"errorType":"MethodError"}', isBase64Encoded: false })
+    }) // end it
+
+    it('MethodError.name', async function() {
+      let Error$1 = errors.MethodError
+      let error = new Error$1('This is a test error')
+      expect(error.name).toEqual('MethodError')
     }) // end it
 
     it('FileError (s3)', async function() {
@@ -292,10 +305,28 @@ describe('Error Handling Tests:', function() {
       expect(result).toEqual({ multiValueHeaders: { }, statusCode: 500, body: '{"errorType":"FileError"}', isBase64Encoded: false })
     }) // end it
 
+    it('FileError.name', async function() {
+      let Error$1 = errors.FileError
+      let error = new Error$1('This is a test error')
+      expect(error.name).toEqual('FileError')
+    }) // end it
+
     it('ResponseError', async function() {
       let _event = Object.assign({},event,{ path: '/responseError' })
       let result = await new Promise(r => api_errors.run(_event,{},(e,res) => { r(res) }))
       expect(result).toEqual({ multiValueHeaders: { }, statusCode: 500, body: '{"errorType":"ResponseError"}', isBase64Encoded: false })
+    }) // end it
+
+    it('ResponseError.name', async function() {
+      let Error$1 = errors.ResponseError
+      let error = new Error$1('This is a test error')
+      expect(error.name).toEqual('ResponseError')
+    }) // end it
+
+    it('ConfigurationError.name', async function() {
+      let Error$1 = errors.ConfigurationError
+      let error = new Error$1('This is a test error')
+      expect(error.name).toEqual('ConfigurationError')
     }) // end it
   })
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -11,7 +11,7 @@
 class RouteError extends Error {
   constructor(message, path) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'RouteError';
     this.path = path;
   }
 }
@@ -19,7 +19,7 @@ class RouteError extends Error {
 class MethodError extends Error {
   constructor(message, method, path) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'MethodError';
     this.method = method;
     this.path = path;
   }
@@ -28,14 +28,14 @@ class MethodError extends Error {
 class ConfigurationError extends Error {
   constructor(message) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'ConfigurationError';
   }
 }
 
 class ResponseError extends Error {
   constructor(message, code) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'ResponseError';
     this.code = code;
   }
 }
@@ -43,7 +43,7 @@ class ResponseError extends Error {
 class FileError extends Error {
   constructor(message, err) {
     super(message);
-    this.name = this.constructor.name;
+    this.name = 'FileError';
     for (let e in err) this[e] = err[e];
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "lambda-api",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.11.1",
+      "name": "lambda-api",
+      "version": "0.11.2",
       "license": "MIT",
       "devDependencies": {
         "@types/aws-lambda": "^8.10.51",


### PR DESCRIPTION
Closes #204 