### PR TITLE
User Provided S3 Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Require the `lambda-api` module into your Lambda handler script and instantiate 
 | serializer           | `Function`            | Optional object serializer function. This function receives the `body` of a response and must return a string. Defaults to `JSON.stringify`                                                               |
 | version              | `String`              | Version number accessible via the `REQUEST` object                                                                                                                                                        |
 | errorHeaderWhitelist | `Array`               | Array of headers to maintain on errors                                                                                                                                                                    |
+| s3Config             | `Object`              | Optional object to provide as config to S3 sdk. [S3ClientConfig](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html)                                 |
 
 ```javascript
 // Require the framework and instantiate it with optional version and base parameters

--- a/__tests__/sendFile.unit.js
+++ b/__tests__/sendFile.unit.js
@@ -184,12 +184,12 @@ api.use(function(err,req,res,next) {
 let stub
 
 describe('SendFile Tests:', function() {
-  let setClientSpy;
+  let setConfigSpy;
 
   beforeEach(function() {
      // Stub getObjectAsync
     stub = sinon.stub(S3,'getObject')
-    setClientSpy = sinon.spy(S3, 'setClient');
+    setConfigSpy = sinon.spy(S3, 'setConfig');
   })
 
   it('Bad path', async function() {
@@ -347,7 +347,7 @@ describe('SendFile Tests:', function() {
   it('S3 file', async function() {
     let _event = Object.assign({},event,{ path: '/sendfile/s3' })
     let result = await new Promise(r => api.run(_event,{},(e,res) => { r(res) }))
-    sinon.assert.calledWith(setClientSpy, undefined);
+    sinon.assert.notCalled(setConfigSpy);
     expect(result).toEqual({
       multiValueHeaders: {
         'content-type': ['text/plain'],
@@ -368,7 +368,7 @@ describe('SendFile Tests:', function() {
     await new Promise(r => apiWithConfig.run(_event,{
       s3Config
     },(e,res) => { r(res) }))
-    sinon.assert.calledWith(setClientSpy, s3Config);
+    sinon.assert.calledWith(setConfigSpy, s3Config);
   }) // end it
 
   it('S3 file w/ nested path', async function() {
@@ -411,7 +411,7 @@ describe('SendFile Tests:', function() {
 
   afterEach(function() {
     stub.restore()
-    setClientSpy.restore();
+    setConfigSpy.restore();
   })
 
 }) // end sendFile tests

--- a/__tests__/sendFile.unit.js
+++ b/__tests__/sendFile.unit.js
@@ -10,7 +10,7 @@ const sinon = require('sinon')
 const S3 = require('../lib/s3-service'); // Init S3 Service
 
 // Init API instance
-const api = require('../index')({ version: 'v1.0', mimeTypes: { test: 'text/test' } })
+const api = require('../index')({ version: 'v1.0', mimeTypes: { test: 'text/test' }})
 
 let event = {
   httpMethod: 'get',
@@ -184,10 +184,12 @@ api.use(function(err,req,res,next) {
 let stub
 
 describe('SendFile Tests:', function() {
+  let setClientSpy;
 
   beforeEach(function() {
      // Stub getObjectAsync
     stub = sinon.stub(S3,'getObject')
+    setClientSpy = sinon.spy(S3, 'setClient');
   })
 
   it('Bad path', async function() {
@@ -345,6 +347,7 @@ describe('SendFile Tests:', function() {
   it('S3 file', async function() {
     let _event = Object.assign({},event,{ path: '/sendfile/s3' })
     let result = await new Promise(r => api.run(_event,{},(e,res) => { r(res) }))
+    sinon.assert.calledWith(setClientSpy, undefined);
     expect(result).toEqual({
       multiValueHeaders: {
         'content-type': ['text/plain'],
@@ -354,6 +357,18 @@ describe('SendFile Tests:', function() {
         'last-modified': result.multiValueHeaders['last-modified']
       }, statusCode: 200, body: 'VGVzdCBmaWxlIGZvciBzZW5kRmlsZQo=', isBase64Encoded: true
     })
+  }) // end it
+
+  it('S3 file w/ custom config',async function() {
+    const s3Config = {
+      endpoint: "http://test"
+    }
+    const apiWithConfig = require('../index')({ version: 'v1.0', mimeTypes: { test: 'text/test' }, s3Config})
+    let _event = Object.assign({},event,{ path: '/sendfile/s3' })
+    await new Promise(r => apiWithConfig.run(_event,{
+      s3Config
+    },(e,res) => { r(res) }))
+    sinon.assert.calledWith(setClientSpy, s3Config);
   }) // end it
 
   it('S3 file w/ nested path', async function() {
@@ -393,8 +408,10 @@ describe('SendFile Tests:', function() {
     })
   }) // end it
 
+
   afterEach(function() {
     stub.restore()
+    setClientSpy.restore();
   })
 
 }) // end sendFile tests

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ const REQUEST = require('./lib/request');
 const RESPONSE = require('./lib/response');
 const UTILS = require('./lib/utils');
 const LOGGER = require('./lib/logger');
+const S3 = require('./lib/s3-service')
 const prettyPrint = require('./lib/prettyPrint');
 const { ConfigurationError } = require('./lib/errors');
 
@@ -45,6 +46,8 @@ class API {
         Array.isArray(props.compression))
         ? props.compression
         : false;
+
+    this._s3Config = props && props.s3Config;
 
     this._sampleCounts = {};
 
@@ -283,6 +286,9 @@ class API {
     this._event = event || {};
     this._context = this.context = typeof context === 'object' ? context : {};
     this._cb = cb ? cb : undefined;
+
+    // Set S3 Client
+    S3.setClient(this._s3Config)
 
     // Initalize request and response objects
     let request = new REQUEST(this);

--- a/index.js
+++ b/index.js
@@ -288,7 +288,7 @@ class API {
     this._cb = cb ? cb : undefined;
 
     // Set S3 Client
-    S3.setClient(this._s3Config);
+    if (this._s3Config) S3.setConfig(this._s3Config);
 
     // Initalize request and response objects
     let request = new REQUEST(this);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const REQUEST = require('./lib/request');
 const RESPONSE = require('./lib/response');
 const UTILS = require('./lib/utils');
 const LOGGER = require('./lib/logger');
-const S3 = require('./lib/s3-service')
+const S3 = require('./lib/s3-service');
 const prettyPrint = require('./lib/prettyPrint');
 const { ConfigurationError } = require('./lib/errors');
 
@@ -288,7 +288,7 @@ class API {
     this._cb = cb ? cb : undefined;
 
     // Set S3 Client
-    S3.setClient(this._s3Config)
+    S3.setClient(this._s3Config);
 
     // Initalize request and response objects
     let request = new REQUEST(this);

--- a/lib/s3-service.js
+++ b/lib/s3-service.js
@@ -11,7 +11,9 @@ const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { streamToBuffer } = require('./utils');
 
 // Export
-exports.client = new S3Client();
+exports.setClient = (config) => {
+  exports.client = new S3Client(config);
+}
 
 exports.getObject = (params) => {
   return {

--- a/lib/s3-service.js
+++ b/lib/s3-service.js
@@ -11,9 +11,7 @@ const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { streamToBuffer } = require('./utils');
 
 // Export
-exports.setClient = (config) => {
-  exports.client = new S3Client(config);
-}
+exports.setClient = (config) => (exports.client = new S3Client(config));
 
 exports.getObject = (params) => {
   return {

--- a/lib/s3-service.js
+++ b/lib/s3-service.js
@@ -11,7 +11,8 @@ const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const { streamToBuffer } = require('./utils');
 
 // Export
-exports.setClient = (config) => (exports.client = new S3Client(config));
+exports.client = new S3Client();
+exports.setConfig = (config) => (exports.client = new S3Client(config));
 
 exports.getObject = (params) => {
   return {


### PR DESCRIPTION
### Allow user to provide configuration for S3 on api init

User may want to change the config of the client for s3. One example of this is during local dev, to change endpoint etc.

I think the only way to currently do this, is to import the client from lambda-api/lib/s3-service.js and override it?

I think it might be a nicer user experience to be able to provide the config on api init. 😄 