### PR TITLE
(feat): Lazy load S3 client

### DIFF
--- a/__tests__/sendFile.unit.js
+++ b/__tests__/sendFile.unit.js
@@ -364,10 +364,6 @@ describe('SendFile Tests:', function() {
       endpoint: "http://test"
     }
     const apiWithConfig = require('../index')({ version: 'v1.0', mimeTypes: { test: 'text/test' }, s3Config})
-    let _event = Object.assign({},event,{ path: '/sendfile/s3' })
-    await new Promise(r => apiWithConfig.run(_event,{
-      s3Config
-    },(e,res) => { r(res) }))
     sinon.assert.calledWith(setConfigSpy, s3Config);
   }) // end it
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const REQUEST = require('./lib/request');
 const RESPONSE = require('./lib/response');
 const UTILS = require('./lib/utils');
 const LOGGER = require('./lib/logger');
-const S3 = require('./lib/s3-service');
+const S3 = () => require('./lib/s3-service');
 const prettyPrint = require('./lib/prettyPrint');
 const { ConfigurationError } = require('./lib/errors');
 
@@ -48,6 +48,9 @@ class API {
         : false;
 
     this._s3Config = props && props.s3Config;
+
+    // Set S3 Client
+    if (this._s3Config) S3().setConfig(this._s3Config);
 
     this._sampleCounts = {};
 
@@ -286,9 +289,6 @@ class API {
     this._event = event || {};
     this._context = this.context = typeof context === 'object' ? context : {};
     this._cb = cb ? cb : undefined;
-
-    // Set S3 Client
-    if (this._s3Config) S3.setConfig(this._s3Config);
 
     // Initalize request and response objects
     let request = new REQUEST(this);

--- a/lib/response.js
+++ b/lib/response.js
@@ -13,7 +13,7 @@ const compression = require('./compression'); // Require compression lib
 const { ResponseError, FileError } = require('./errors'); // Require custom errors
 
 // Lazy load AWS S3 service
-const S3 = () => (require('./s3-service'));
+const S3 = () => require('./s3-service');
 
 class RESPONSE {
   // Create the constructor function.

--- a/lib/response.js
+++ b/lib/response.js
@@ -12,8 +12,8 @@ const path = require('path'); // Require Node.js path
 const compression = require('./compression'); // Require compression lib
 const { ResponseError, FileError } = require('./errors'); // Require custom errors
 
-// Require AWS S3 service
-const S3 = require('./s3-service');
+// Lazy load AWS S3 service
+const S3 = () => (require('./s3-service'));
 
 class RESPONSE {
   // Create the constructor function.
@@ -195,7 +195,7 @@ class RESPONSE {
 
     // getSignedUrl doesn't support .promise()
     return await new Promise((r) =>
-      S3.getSignedUrl('getObject', params, async (e, url) => {
+      S3().getSignedUrl('getObject', params, async (e, url) => {
         if (e) {
           // Execute callback with caught error
           await fn(e);
@@ -336,7 +336,7 @@ class RESPONSE {
           let params = UTILS.parseS3(filepath);
 
           // Attempt to get the object from S3
-          let data = await S3.getObject(params).promise();
+          let data = await S3().getObject(params).promise();
 
           // Set results, type and header
           buffer = data.Body;


### PR DESCRIPTION
This lazy loads the S3 client so it no longer adds ~100 ms to coldstarts if you minify your bundle and don't use S3.  If you are using the on disk version of `client-s3`, it reduces coldstarts by ~300ms. By lazy loading you can also omit `client-s3` in a minified bundle if you don't use it reducing the bundled package size by over 340 KB.  While making this change I noticed that the call to `setConfig` when using a custom s3 client was in the `run` method causing a new S3Client to be created for every request.  I moved the `setConfig` call to the `createAPI` method so the same S3 client is reused across requests.