### PR TITLE
Add multiValueHeaders type to Request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -154,6 +154,9 @@ export declare class Request {
   headers: {
     [key: string]: string | undefined;
   };
+  multiValueHeaders: {
+    [key: string]: string | undefined;
+  };
   rawHeaders?: {
     [key: string]: string | undefined;
   };


### PR DESCRIPTION
The `Response` type declaration is lacking the definition for `multiValueHeaders`