### PR TITLE
Correct type of multiValueHeaders

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -155,7 +155,7 @@ export declare class Request {
     [key: string]: string | undefined;
   };
   multiValueHeaders: {
-    [key: string]: string | undefined;
+    [key: string]: string[] | undefined;
   };
   rawHeaders?: {
     [key: string]: string | undefined;


### PR DESCRIPTION
This PR updates the typing of `Request#multiValueHeaders` to make the header values arrays.

Closes #274 