### PR TITLE
Add TypeScript support for ALB related types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
 import {
+  ALBEvent,
+  ALBEventRequestContext,
   APIGatewayEventRequestContext,
   APIGatewayProxyEvent,
   APIGatewayProxyEventV2,
@@ -163,7 +165,7 @@ export declare class Request {
   body: any;
   rawBody: string;
   route: '';
-  requestContext: APIGatewayEventRequestContext;
+  requestContext: APIGatewayEventRequestContext | ALBEventRequestContext;
   isBase64Encoded: boolean;
   pathParameters: { [name: string]: string } | null;
   stageVariables: { [name: string]: string } | null;
@@ -343,12 +345,12 @@ export declare class API {
   finally(callback: FinallyFunction): void;
 
   run(
-    event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
+    event: APIGatewayProxyEvent | APIGatewayProxyEventV2 | ALBEvent,
     context: Context,
     cb: (err: Error, result: any) => void
   ): void;
   run(
-    event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
+    event: APIGatewayProxyEvent | APIGatewayProxyEventV2 | ALBEvent,
     context: Context
   ): Promise<any>;
 }


### PR DESCRIPTION
This library has ALB integration but current TypeScript types do not reflect this.

For example the `API#run`  method does not accept an `ALBEvent` type meaning that if someone wants to be extremely correct the fix is something like the following:
```ts
async function handler(event: ALBEvent, context: Context): Promise<any> {
  return api.run(event as unknown as APIGatewayProxyEvent, context);
}
```

This PR aims to fix this.