### PR TITLE
Security: Prototype pollution risk in recursive object merge

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,10 +156,17 @@ exports.parseS3 = (path) => {
 
 // Deep Merge
 exports.deepMerge = (a, b) => {
+  const blockedKeys = ['__proto__', 'prototype', 'constructor'];
   Object.keys(b).forEach((key) => {
-    if (key === '__proto__') return;
-    if (typeof b[key] !== 'object') return Object.assign(a, b);
-    return key in a ? this.deepMerge(a[key], b[key]) : Object.assign(a, b);
+    if (blockedKeys.includes(key)) return;
+    if (b[key] && typeof b[key] === 'object' && !Array.isArray(b[key])) {
+      if (!a[key] || typeof a[key] !== 'object' || Array.isArray(a[key])) {
+        a[key] = {};
+      }
+      this.deepMerge(a[key], b[key]);
+    } else {
+      a[key] = b[key];
+    }
   });
   return a;
 };


### PR DESCRIPTION
## Problem

`deepMerge` only blocks the `__proto__` key, but still recursively merges attacker-controlled nested objects and uses `Object.assign(a, b)` on non-object branches. This can allow pollution through `constructor.prototype`-style payloads or unsafe key propagation when untrusted input reaches merge paths.

**Severity**: `high`
**File**: `lib/utils.js`

## Solution

Harden merge logic by explicitly rejecting `__proto__`, `prototype`, and `constructor` at every depth; avoid `Object.assign(a, b)` with untrusted objects; and consider replacing with a vetted safe-merge utility that prevents prototype mutation.

## Changes

- `lib/utils.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
