### PR TITLE
Security: Unbounded memory consumption when buffering S3 object streams

### DIFF
--- a/lib/s3-service.js
+++ b/lib/s3-service.js
@@ -8,7 +8,31 @@
 // Require AWS SDK
 const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3'); // AWS SDK
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
-const { streamToBuffer } = require('./utils');
+const MAX_BUFFERED_OBJECT_SIZE = parseInt(
+  process.env.AWS_S3_MAX_BUFFERED_OBJECT_SIZE ||
+    process.env.AWS_S3_MAX_OBJECT_SIZE ||
+    10485760,
+  10
+);
+
+const streamToBufferWithLimit = async (stream, maxSize) => {
+  const chunks = [];
+  let size = 0;
+
+  for await (const chunk of stream) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    size += buffer.length;
+
+    if (size > maxSize) {
+      if (typeof stream.destroy === 'function') stream.destroy();
+      throw new Error('S3 object exceeds maximum allowed buffered size');
+    }
+
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks);
+};
 
 // Export
 exports.client = new S3Client();
@@ -21,9 +45,18 @@ exports.getObject = (params) => {
 
       if (!res.Body) return res;
 
+      if (
+        Number.isFinite(MAX_BUFFERED_OBJECT_SIZE) &&
+        MAX_BUFFERED_OBJECT_SIZE > 0 &&
+        typeof res.ContentLength === 'number' &&
+        res.ContentLength > MAX_BUFFERED_OBJECT_SIZE
+      ) {
+        throw new Error('S3 object exceeds maximum allowed buffered size');
+      }
+
       return {
         ...res,
-        Body: await streamToBuffer(res.Body),
+        Body: await streamToBufferWithLimit(res.Body, MAX_BUFFERED_OBJECT_SIZE),
       };
     },
   };


### PR DESCRIPTION
## Problem

`getObject` converts the entire S3 response stream into a Buffer via `streamToBuffer` with no size limit. Large objects can exhaust Lambda memory and cause denial of service if object size is attacker-influenced or not strictly controlled.

**Severity**: `high`
**File**: `lib/s3-service.js`

## Solution

Avoid full buffering for arbitrary objects. Enforce a maximum allowed content length before reading, stream directly to the client/storage when possible, and abort reads when size thresholds are exceeded.

## Changes

- `lib/s3-service.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
