### PR TITLE
ci: add npm release workflow with OIDC trusted publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install NPM

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,11 +12,11 @@ jobs:
     name: Node ${{ matrix.node }}
     steps:
       - name: 'Checkout latest code'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
@@ -32,11 +32,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
           cache: 'npm'
@@ -50,11 +50,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: 'Release'
+
+on:
+  release:
+    types: [published]
+
+# Least-privilege by default; the publish job opts into id-token below.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: 'Test (Node ${{ matrix.node }})'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [14, 16, 18, 20, 22]
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v4
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      - name: Install NPM (if node 14)
+        run: if [ "${{ matrix.node }}" == "14" ]; then npm install -g npm@9; fi
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test
+
+  publish:
+    name: 'Publish to npm'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm OIDC trusted publishing + provenance
+    steps:
+      - name: Checkout latest code
+        uses: actions/checkout@v4
+      - name: Set up node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Ensure npm supports trusted publishing
+        # Trusted publishing requires npm >= 11.5.1.
+        run: npm install -g npm@latest
+      - name: Verify release tag matches package.json version
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::Release tag '$TAG' does not match package.json version '$PKG_VERSION'"
+            exit 1
+          fi
+      - name: Install dependencies
+        run: npm ci
+      - name: Publish to npm
+        # No NODE_AUTH_TOKEN: auth happens via OIDC, provenance is automatic.
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Whatever you decide is best for your use case, **Lambda API** is there to suppor
 npm i lambda-api --save
 ```
 
+Releases are published to npm via GitHub Actions using [trusted publishing (OIDC)](https://docs.npmjs.com/trusted-publishers), so every published version ships with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) — a signed, verifiable link back to the exact commit and workflow that built it.
+
 ## Requirements
 
 - AWS Lambda running **Node 8.10+**


### PR DESCRIPTION
## Summary
- Add `.github/workflows/release.yml`: on **GitHub Release published**, run the full test matrix (Node 14–22) then publish to npm via **OIDC trusted publishing** — no stored `NODE_AUTH_TOKEN`, automatic provenance.
- A guard step fails the release if the release tag doesn't match `package.json`'s version.
- Bump deprecated action versions to `v4` in `build.yml` (`checkout@v2`, `setup-node@v1`) and `pull-request.yml` (`checkout@v3`, `setup-node@v3`).
- Document trusted publishing / provenance under Installation in the README.

## Required one-time setup before first release
On npmjs.com → `lambda-api` package → Settings → Trusted Publisher, add a GitHub Actions publisher:
- Organization/user: `jeremydaly`
- Repository: `lambda-api`
- Workflow filename: `release.yml`
- Allowed action: `npm publish`

Until configured, the publish step will fail auth.

## Release flow
Bump `version` in `package.json`, commit, then create a GitHub Release with tag `vX.Y.Z` matching that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)