### PR TITLE
ci: set release version at publish time + allow manual publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: 'Release'
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 1.2.0 or v1.2.0)'
+        required: true
+        type: string
 
 # Least-privilege by default; the publish job opts into id-token below.
 permissions:
@@ -48,16 +54,22 @@ jobs:
       - name: Ensure npm supports trusted publishing
         # Trusted publishing requires npm >= 11.5.1.
         run: npm install -g npm@latest
-      - name: Verify release tag matches package.json version
-        run: |
-          PKG_VERSION="v$(node -p "require('./package.json').version")"
-          TAG="${{ github.event.release.tag_name }}"
-          if [ "$PKG_VERSION" != "$TAG" ]; then
-            echo "::error::Release tag '$TAG' does not match package.json version '$PKG_VERSION'"
-            exit 1
-          fi
       - name: Install dependencies
         run: npm ci
+      - name: Set version to publish
+        # package.json ships a 0.0.0-development placeholder; the real version
+        # comes from the manual input (workflow_dispatch) or the release tag,
+        # with any leading "v" stripped (e.g. v1.2.0 -> 1.2.0).
+        run: |
+          VERSION="${INPUT_VERSION:-$TAG}"
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version provided" && exit 1
+          fi
+          npm pkg set version="${VERSION#v}"
+          echo "Publishing version ${VERSION#v}"
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          TAG: ${{ github.event.release.tag_name }}
       - name: Publish to npm
         # No NODE_AUTH_TOKEN: auth happens via OIDC, provenance is automatic.
         run: npm publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambda-api",
-  "version": "1.2.0",
+  "version": "0.0.0-development",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lambda-api",
-      "version": "1.2.0",
+      "version": "0.0.0-development",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-s3": "3.470.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambda-api",
-  "version": "1.2.0",
+  "version": "0.0.0-development",
   "description": "Lightweight web framework for your serverless applications",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Follow-up to #317 (already merged). That PR added the npm release workflow with OIDC trusted publishing and bumped the action versions. This PR adds the two pieces that didn't make it into the merge:

## Summary
- **Version set at publish time.** `package.json` (and `package-lock.json`, to keep `npm ci` in sync) now carry a `0.0.0-development` placeholder. The real version is applied just before `npm publish` via `npm pkg set version=…`.
- **Manual publish.** Added a `workflow_dispatch` trigger with a required `version` input (accepts `1.2.0` or `v1.2.0`). The version step prefers the manual input and falls back to the release tag, stripping a leading `v`.

## Publish paths
- **Release published** → version comes from the release tag.
- **Run workflow → enter version** (Actions tab) → version comes from your input.

Tests (Node 14–22) still gate publishing on both triggers.

## Note
Manual `workflow_dispatch` publishes to npm only — it does not create a git tag or GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)