### PR TITLE
Cover redirect Authorization header behavior (closes #149)

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,8 @@ api.get('/redirectToS3File', (req, res) => {
 });
 ```
 
+**NOTE:** `removeHeader()` only affects the **response** headers Lambda API sends back. Lambda API never copies the incoming request's `Authorization` header onto the response, so `res.removeHeader('authorization')` has nothing to strip in that case. If a redirect to a signed S3 URL fails because an `Authorization` header is being forwarded, that header is being re-sent by your **HTTP client** when it follows the `3xx` to the signed URL (S3 rejects requests that combine an `Authorization` header with query-string signing). Because that happens on the client's follow-up request after Lambda API has already responded, it cannot be removed server-side. Configure your client to drop `Authorization` on cross-origin redirects, or return the [`getLink()`](#getlinks3path--expires--callback) URL in the response body for the client to fetch directly instead of redirecting.
+
 ### cors([options])
 
 Convenience method for adding [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) headers to responses. An optional `options` object can be passed in to customize the defaults.

--- a/__tests__/responses.unit.js
+++ b/__tests__/responses.unit.js
@@ -111,6 +111,16 @@ api.get('/s3Path', function(req,res) {
   res.redirect('s3://my-test-bucket/test/test.txt')
 })
 
+// Issue #149: removeHeader should strip a response Authorization header before redirecting
+api.get('/redirectRemoveAuth', function(req,res) {
+  res.header('Authorization', 'Bearer SECRET').removeHeader('authorization').redirect('https://example.com/signed-url')
+})
+
+// Issue #149: the incoming request Authorization header must never leak into the redirect response
+api.get('/redirectKeepsRequestClean', function(req,res) {
+  res.redirect('https://example.com/signed-url')
+})
+
 api3.get('/test', function(req,res) {
   res.send({ object: true })
 })
@@ -259,6 +269,20 @@ describe('Response Tests:', function() {
       isBase64Encoded: false
     })
     expect(stub.lastCall.args[1]).toEqual({ Bucket: 'my-test-bucket', Key: 'test/test.txt', Expires: 900 })
+  }) // end it
+
+  it('Redirect (removeHeader strips response Authorization header - issue #149)', async function() {
+    let _event = Object.assign({},event,{ path: '/redirectRemoveAuth' })
+    let result = await new Promise(r => api.run(_event,{},(e,res) => { r(res) }))
+    expect(result).toEqual({ multiValueHeaders: { 'content-type': ['text/html'], 'location': ['https://example.com/signed-url'] }, statusCode: 302, body: '<p>302 Redirecting to <a href="https://example.com/signed-url">https://example.com/signed-url</a></p>', isBase64Encoded: false })
+    expect(result.multiValueHeaders).not.toHaveProperty('authorization')
+  }) // end it
+
+  it('Redirect (request Authorization header is not leaked into the response - issue #149)', async function() {
+    let _event = Object.assign({},event,{ path: '/redirectKeepsRequestClean', multiValueHeaders: { authorization: ['Bearer CLIENT-TOKEN'] } })
+    let result = await new Promise(r => api.run(_event,{},(e,res) => { r(res) }))
+    expect(result).toEqual({ multiValueHeaders: { 'content-type': ['text/html'], 'location': ['https://example.com/signed-url'] }, statusCode: 302, body: '<p>302 Redirecting to <a href="https://example.com/signed-url">https://example.com/signed-url</a></p>', isBase64Encoded: false })
+    expect(result.multiValueHeaders).not.toHaveProperty('authorization')
   }) // end it
 
 


### PR DESCRIPTION
## Summary

Resolves #149 ("Redirect and Remove Authorization Header").

Investigation showed there is **no library bug**:

- `res.removeHeader('authorization')` correctly removes a header from the **response** (`lib/response.js:109`).
- lambda-api **never** copies the incoming request's `Authorization` header onto the response.

The reported failure — the `Authorization` header being forwarded to an S3 signed URL — is caused by the **HTTP client** re-sending the original `Authorization` header when it follows the `3xx` redirect to the signed URL. S3 rejects requests that combine an `Authorization` header with query-string signing. Because that happens on the client's follow-up request after lambda-api has already responded, it cannot be stripped server-side.

## Changes

- **Regression tests** (`__tests__/responses.unit.js`) locking in the correct behavior:
  - `removeHeader('authorization')` strips a response-level `Authorization` header before a redirect.
  - The incoming request's `Authorization` header is never leaked into the redirect response.
- **README** note in the `redirect()` section explaining the client-side cause and the recommended workarounds (drop `Authorization` on cross-origin redirects, or return a `getLink()` URL in the body instead of redirecting).

## Testing

`npx jest __tests__/responses.unit.js` — 28/28 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)