### PR TITLE
docs: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [naorpeled]


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the **Sponsor** button appears on the repo page, pointing to the `naorpeled` GitHub Sponsors profile.