### PR TITLE
fix(ci): build dist before running benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,6 +42,15 @@ jobs:
           RAW="${{ github.event.release.tag_name || inputs.version }}"
           echo "value=${RAW#v}" >> "$GITHUB_OUTPUT"
 
+      # The benchmark adapter loads lambda-api from the working tree via require('../../'),
+      # which resolves through the root package's "main" (./dist/cjs/index.js). That path
+      # only exists after a build, so the root package must be installed and built first.
+      - name: Install root dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build dist (CJS + ESM)
+        run: npm run build
+
       - name: Install benchmark dependencies
         working-directory: benchmarks
         run: npm ci

--- a/benchmarks/frameworks/lambda-api.js
+++ b/benchmarks/frameworks/lambda-api.js
@@ -26,4 +26,9 @@ function build() {
   return (event, context) => api.run(event, context);
 }
 
-module.exports = { name: 'lambda-api', version: pkg.version, build };
+// package.json ships a 0.0.0-development placeholder (the real version is stamped at
+// publish time), so prefer the release label the workflow passes in — same precedence
+// as the run metadata in run.js.
+const version = process.env.LAMBDA_API_VERSION || pkg.version;
+
+module.exports = { name: 'lambda-api', version, build };


### PR DESCRIPTION
The Benchmarks workflow crashed on the v1.5.0 release ([run 31267507913](https://github.com/jeremydaly/lambda-api/actions/runs/31267507913)):

```
Error: Cannot find module '/home/runner/work/lambda-api/lambda-api/dist/cjs/index.js'.
Please verify that the package.json has a valid "main" entry
    at Object.<anonymous> (benchmarks/frameworks/lambda-api.js:10:19)
```

## Root cause

`benchmarks/frameworks/lambda-api.js` loads the library from the working tree with `require('../../')`, which resolves through the root package's `main`. #326 changed `main` from `index.js` to `./dist/cjs/index.js`, so the adapter now requires a build — but the workflow only ran `npm ci` inside `benchmarks/`, never installing or building the root package.

The benchmark suite (#327) merged before the dual build (#326), and benchmarks only run on `release: published`, so v1.5.0 was the first time the two met. The `baseline` framework has no lambda-api dependency and completed fine, which is why the log shows 10 green scenarios before the crash.

## Fixes

**1. Build `dist/` before benchmarking.** Adds a root `npm ci --ignore-scripts` + `npm run build` ahead of the benchmark install, matching how `release.yml` sequences the same steps.

**2. Honor `LAMBDA_API_VERSION` in the adapter.** Surfaced while verifying the first fix. `run.js:65` already read the env var, but only for the run metadata that renders the caption — the per-framework table rows use each adapter's own `version` field, and lambda-api's read `package.json` directly. Since that ships a `0.0.0-development` placeholder until publish time, every table row would have rendered as:

```
| lambda-api `0.0.0-development` | 298,049 | ...
```

while the caption directly above it correctly said `lambda-api v1.5.0`. That would have been committed straight into the README by the workflow's final step. The adapter now uses the same `LAMBDA_API_VERSION || pkg.version` precedence as `run.js`.

## Verification

Reproduced locally by deleting `dist/` — same `MODULE_NOT_FOUND` at the same adapter line; loads cleanly after `npm run build`.

Ran the exact workflow command end-to-end (`node run.js --md results/RESULTS.md --json results/raw.json --update-readme` with `LAMBDA_API_VERSION=1.5.0`). All 6 frameworks × 10 scenarios complete, and both the caption and every table row now read `1.5.0`. Generated results were reverted out of this branch — the committed numbers should come from the runner, not my laptop.

The subsequent `Format README` step pins `prettier@2`, which matches the repo's `^2.3.2` devDependency, so no version skew there.

## Note

The v1.5.0 README still has stale benchmark numbers, since the workflow never reached its commit step. Once this merges, re-running the workflow via `workflow_dispatch` with version `1.5.0` will refresh it.
